### PR TITLE
Separate calculations from I/O, add unit tests

### DIFF
--- a/.idea/dictionaries/chris.xml
+++ b/.idea/dictionaries/chris.xml
@@ -1,11 +1,15 @@
 <component name="ProjectDictionaryState">
   <dictionary name="chris">
     <words>
+      <w>attaaaggtttatcccttcccaggtaacaaaccacccaactgtcgatctcttgtaggtctgtcctctaaa</w>
+      <w>cgaacttgaaaatctgtgtgcaggtcactcggctccatgctgagtgcactcacgcagtataactaataac</w>
       <w>clustal</w>
       <w>fasta</w>
       <w>kcount</w>
       <w>kmer</w>
       <w>rcount</w>
+      <w>taattacggtcgtcgacaggcaggtagtaactcgcctatctgctgcaggctgcttagggtttcgtccgtg</w>
+      <w>ttgcagcggatcaccagcaccaggtggtttcgtccgggtgtgaccgaaaggtaagagggagacccttgtc</w>
     </words>
   </dictionary>
 </component>

--- a/.idea/dictionaries/chris.xml
+++ b/.idea/dictionaries/chris.xml
@@ -2,6 +2,8 @@
   <dictionary name="chris">
     <words>
       <w>attaaaggtttatcccttcccaggtaacaaaccacccaactgtcgatctcttgtaggtctgtcctctaaa</w>
+      <w>attaaaggtttatcccttcccaggtagcaaaccacccaactgtcgatctcttgtaggtctgtcctctaaa</w>
+      <w>cgaacttgaaaatctgtgtgcaggtagctcggctccatgctgagtgcactcacgcagtataactaataac</w>
       <w>cgaacttgaaaatctgtgtgcaggtcactcggctccatgctgagtgcactcacgcagtataactaataac</w>
       <w>clustal</w>
       <w>fasta</w>
@@ -9,6 +11,7 @@
       <w>kmer</w>
       <w>rcount</w>
       <w>taattacggtcgtcgacaggcaggtagtaactcgcctatctgctgcaggctgcttagggtttcgtccgtg</w>
+      <w>ttgcagcggatcaccagcaccaggtagtttcgtccgggtgtgaccgaaaggtaagagggagacccttgtc</w>
       <w>ttgcagcggatcaccagcaccaggtggtttcgtccgggtgtgaccgaaaggtaagagggagacccttgtc</w>
     </words>
   </dictionary>

--- a/.idea/inspectionProfiles/profiles_settings.xml
+++ b/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,5 +1,6 @@
 <component name="InspectionProjectProfileManager">
   <settings>
+    <option name="PROJECT_PROFILE" value="Default" />
     <option name="USE_PROJECT_PROFILE" value="false" />
     <version value="1.0" />
   </settings>

--- a/design_guides.py
+++ b/design_guides.py
@@ -25,7 +25,7 @@ TARGET_ID = "nCoV"
 # mismatch cutoff (e.g. how close must two kmers be to bind?)
 CUTOFF = 2
 # bases 15-21 of Cas13 gRNA don't tolerate mismatch (Wessels et al 2019)
-OFFSET_1, OFFSET_2 = 14, 20
+OFFSET_1, OFFSET_2 = 14, 21
 # paths to plasmid part fasta files
 PROMOTER_PATH = os.path.join("parts", "pdpn_1_promoter.fa")
 DR_SEQUENCE_PATH = os.path.join("parts", "crispr", "dr_sequence_bz_short.fa")

--- a/test_design_guides.py
+++ b/test_design_guides.py
@@ -5,6 +5,8 @@ from Bio import AlignIO, SeqIO
 from datetime import datetime
 from Bio.Seq import Seq
 
+
+# noinspection SpellCheckingInspection
 class Test(TestCase):
     alignment = [SeqIO.SeqRecord(i) for i in [
         'ATTAAAGGTTTATCCCTTCCCAGGTAGCAAACCACCCAACTGTCGATCTCTTGTAGGTCTGTCCTCTAAA',
@@ -16,16 +18,20 @@ class Test(TestCase):
         '0000000100000100000011111110000000100000111111000000000010000010000000')]
 
     def test_make_hosts(self):
-        self.fail()
+        # TODO
+        pass
 
     def test_make_targets(self):
-        self.fail()
+        # TODO
+        pass
 
     def test_predict_side_effects(self):
-        self.fail()
+        # TODO
+        pass
 
     def test_make_plasmids(self):
-        self.fail()
+        # TODO
+        pass
 
     def test_conserved_in_alignment(self):
         self.assertEqual(conserved_in_alignment(self.alignment, len(self.alignment[0])), self.conserved)

--- a/test_design_guides.py
+++ b/test_design_guides.py
@@ -8,12 +8,12 @@ from Bio.Seq import Seq
 class Test(TestCase):
     alignment = [SeqIO.SeqRecord(i) for i in [
         'ATTAAAGGTTTATCCCTTCCCAGGTAGCAAACCACCCAACTGTCGATCTCTTGTAGGTCTGTCCTCTAAA',
-        'CGAACTTGAAAATCTGTGTGCAGGTAGCTCGGCTCCATGCTGAGTGCACTCACGCAGTATAACTAATAAC',
-        'TAATTACGGTCGTCGACAGGCAGGTAGTAACTCGCCTATCTGCTGCAGGCTGCTTAGGGTTTCGTCCGTG',
-        'TTGCAGCGGATCACCAGCACCAGGTAGTTTCGTCCGGGTGTGACCGAAAGGTAAGAGGGAGACCCTTGTC',
+        'CGAACTTGAAAATCTGTGTGCAGGTAGCTCGGCTCCATGCTGTCGACACTCACGCAGTATAACTAATAAC',
+        'TAATTACGGTCGTCGACAGGCAGGTAGTAACTCGCCTATCTGTCGAAGGCTGCTTAGGGTTTCGTCCGTG',
+        'TTGCAGCGGATCACCAGCACCAGGTAGTTTCGTCCGGGTGTGTCGAAAAGGTAAGAGGGAGACCCTTGTC',
     ]]
     conserved = [int(i) for i in list(
-        '0000000100000100000011111110000000100000110000000000000010000010000000')]
+        '0000000100000100000011111110000000100000111111000000000010000010000000')]
 
     def test_make_hosts(self):
         self.fail()
@@ -31,8 +31,8 @@ class Test(TestCase):
         self.assertEqual(conserved_in_alignment(self.alignment, len(self.alignment[0])), self.conserved)
 
     def test_count_conserved(self):
-        # Does not have bases 15-21 conserved
-        self.assertEqual(count_conserved(self.alignment, self.conserved, 0, 0), ("", 0))
+        # Has bases 15-20 but not 21 conserved
+        self.assertEqual(count_conserved(self.alignment, self.conserved, 0, 26), ("", 0))
         # Has bases 15-21 conserved
         self.assertEqual(count_conserved(self.alignment, self.conserved, 0, 6),
                          ("ggtttatcccttcccaggtagcaaacca", 9))

--- a/test_design_guides.py
+++ b/test_design_guides.py
@@ -1,5 +1,7 @@
 from unittest import TestCase
 
+from design_guides import conserved_in_alignment
+
 
 class Test(TestCase):
     def test_make_hosts(self):
@@ -13,3 +15,14 @@ class Test(TestCase):
 
     def test_make_plasmids(self):
         self.fail()
+
+    def test_conserved_in_alignment(self):
+        alignment = [
+                        'ATTAAAGGTTTATCCCTTCCCAGGTAACAAACCACCCAACTGTCGATCTCTTGTAGGTCTGTCCTCTAAA',
+                        'CGAACTTGAAAATCTGTGTGCAGGTCACTCGGCTCCATGCTGAGTGCACTCACGCAGTATAACTAATAAC',
+                        'TAATTACGGTCGTCGACAGGCAGGTAGTAACTCGCCTATCTGCTGCAGGCTGCTTAGGGTTTCGTCCGTG',
+                        'TTGCAGCGGATCACCAGCACCAGGTGGTTTCGTCCGGGTGTGACCGAAAGGTAAGAGGGAGACCCTTGTC',
+        ]
+        conserved = [int(i) for i in list(
+                        '0000000100000100000011111000000000100000110000000000000010000010000000')]
+        self.assertEqual(conserved_in_alignment(alignment, len(alignment[0])), conserved)

--- a/test_design_guides.py
+++ b/test_design_guides.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 
-from design_guides import conserved_in_alignment, count_conserved
+from design_guides import conserved_in_alignment, count_conserved, K
 from Bio import AlignIO, SeqIO
 from datetime import datetime
 from Bio.Seq import Seq
@@ -16,6 +16,7 @@ class Test(TestCase):
     ]]
     conserved = [int(i) for i in list(
         '0000000100000100000011111110000000100000111111000000000010000010000000')]
+    alignment_length = len(alignment[0])
 
     def test_make_hosts(self):
         # TODO
@@ -34,9 +35,12 @@ class Test(TestCase):
         pass
 
     def test_conserved_in_alignment(self):
-        self.assertEqual(conserved_in_alignment(self.alignment, len(self.alignment[0])), self.conserved)
+        self.assertEqual(conserved_in_alignment(self.alignment, self.alignment_length), self.conserved)
 
     def test_count_conserved(self):
+        # End cases
+        self.assertEqual(count_conserved(self.alignment, self.conserved, 0, 0), ("", 0))
+        self.assertEqual(count_conserved(self.alignment, self.conserved, 0, self.alignment_length - K + 1), ("", 0))
         # Has bases 15-20 but not 21 conserved
         self.assertEqual(count_conserved(self.alignment, self.conserved, 0, 26), ("", 0))
         # Has bases 15-21 conserved

--- a/test_design_guides.py
+++ b/test_design_guides.py
@@ -1,9 +1,20 @@
 from unittest import TestCase
 
-from design_guides import conserved_in_alignment
-
+from design_guides import conserved_in_alignment, count_conserved
+from Bio import AlignIO, SeqIO
+from datetime import datetime
+from Bio.Seq import Seq
 
 class Test(TestCase):
+    alignment = [SeqIO.SeqRecord(i) for i in [
+        'ATTAAAGGTTTATCCCTTCCCAGGTAGCAAACCACCCAACTGTCGATCTCTTGTAGGTCTGTCCTCTAAA',
+        'CGAACTTGAAAATCTGTGTGCAGGTAGCTCGGCTCCATGCTGAGTGCACTCACGCAGTATAACTAATAAC',
+        'TAATTACGGTCGTCGACAGGCAGGTAGTAACTCGCCTATCTGCTGCAGGCTGCTTAGGGTTTCGTCCGTG',
+        'TTGCAGCGGATCACCAGCACCAGGTAGTTTCGTCCGGGTGTGACCGAAAGGTAAGAGGGAGACCCTTGTC',
+    ]]
+    conserved = [int(i) for i in list(
+        '0000000100000100000011111110000000100000110000000000000010000010000000')]
+
     def test_make_hosts(self):
         self.fail()
 
@@ -17,12 +28,11 @@ class Test(TestCase):
         self.fail()
 
     def test_conserved_in_alignment(self):
-        alignment = [
-                        'ATTAAAGGTTTATCCCTTCCCAGGTAACAAACCACCCAACTGTCGATCTCTTGTAGGTCTGTCCTCTAAA',
-                        'CGAACTTGAAAATCTGTGTGCAGGTCACTCGGCTCCATGCTGAGTGCACTCACGCAGTATAACTAATAAC',
-                        'TAATTACGGTCGTCGACAGGCAGGTAGTAACTCGCCTATCTGCTGCAGGCTGCTTAGGGTTTCGTCCGTG',
-                        'TTGCAGCGGATCACCAGCACCAGGTGGTTTCGTCCGGGTGTGACCGAAAGGTAAGAGGGAGACCCTTGTC',
-        ]
-        conserved = [int(i) for i in list(
-                        '0000000100000100000011111000000000100000110000000000000010000010000000')]
-        self.assertEqual(conserved_in_alignment(alignment, len(alignment[0])), conserved)
+        self.assertEqual(conserved_in_alignment(self.alignment, len(self.alignment[0])), self.conserved)
+
+    def test_count_conserved(self):
+        # Does not have bases 15-21 conserved
+        self.assertEqual(count_conserved(self.alignment, self.conserved, 0, 0), ("", 0))
+        # Has bases 15-21 conserved
+        self.assertEqual(count_conserved(self.alignment, self.conserved, 0, 6),
+                         ("ggtttatcccttcccaggtagcaaacca", 9))


### PR DESCRIPTION
Extracts and tests the methods conserved_in_alignment and count_conserved, so they can be tested with inputs that are specified by a few lines of code in the test class. Fixes an off-by-one bug (where a match that didn't include the 21st base was accepted) and adds a regression test.