### PR TITLE
Optimizations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,3 @@ trie.*
 /db/
 /venv-pypy/
 /db-old/
-/venv-pypy/

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ human_transcriptome.fna
 trie.*
 /venv/
 /db/
+/venv-pypy/
+/db-old/
+/venv-pypy/

--- a/.idea/coronavirus.iml
+++ b/.idea/coronavirus.iml
@@ -2,7 +2,9 @@
 <module type="PYTHON_MODULE" version="4">
   <component name="NewModuleRootManager">
     <content url="file://$MODULE_DIR$">
+      <excludeFolder url="file://$MODULE_DIR$/db-old" />
       <excludeFolder url="file://$MODULE_DIR$/venv" />
+      <excludeFolder url="file://$MODULE_DIR$/venv-pypy" />
     </content>
     <orderEntry type="jdk" jdkName="Python 3.7 (coronavirus)" jdkType="Python SDK" />
     <orderEntry type="sourceFolder" forTests="false" />

--- a/design_guides.py
+++ b/design_guides.py
@@ -68,7 +68,9 @@ def index(kmer, db=leveldb):
             prefix_str = kmer[:x]
             prefix = bytesu(prefix_str)
             old_value = db.get(prefix, EMPTY_BYTES)
-            new_value = bytesu(''.join(sorted(set(str(old_value) + kmer[x]))))
+            new_value_set = set(old_value)
+            new_value_set.add(ord(kmer[x]))
+            new_value = bytesu(sorted(new_value_set))
             if old_value != new_value:
                 wb.put(prefix, new_value)
         wb.put(bytesu(kmer), END_BYTES)

--- a/design_guides.py
+++ b/design_guides.py
@@ -66,8 +66,7 @@ def index(kmer, db=leveldb):
             prefix_str = kmer[:x]
             prefix = bytesu(prefix_str)
             old_value = db.get(prefix, EMPTY_BYTES)
-            nextchar = kmer[x]
-            new_value = add_to_bytes_as_set(nextchar, old_value)
+            new_value = add_to_bytes_as_set(kmer[x], old_value)
             if old_value != new_value:
                 wb.put(prefix, new_value)
         wb.put(bytesu(kmer), END_BYTES)

--- a/design_guides.py
+++ b/design_guides.py
@@ -61,14 +61,15 @@ def getKmers(sequence, k, step):
 
 
 def index(kmer, db=leveldb):
+    kmer_bytes = bytesu(kmer)
     with db.write_batch() as wb:
         for x in range(1, len(kmer) - 1):
-            prefix = bytesu(kmer[:x])
+            prefix = kmer_bytes[:x]
             old_value = db.get(prefix, EMPTY)
             new_value = add_to_bytes_as_set(kmer[x], old_value)
             if old_value != new_value:
                 wb.put(prefix, new_value)
-        wb.put(bytesu(kmer), END)
+        wb.put(kmer_bytes, END)
 
 
 def add_to_bytes_as_set(char, dest):

--- a/design_guides.py
+++ b/design_guides.py
@@ -62,19 +62,16 @@ def getKmers(sequence: str, k: int, step: int):
 
 
 def index(kmer: str, db=leveldb):
-    kmer_bytes = bytesu(kmer)
+    kmer_bytes = bytesu([*kmer, '*'])
     with db.write_batch() as wb:
-        for x in range(1, len(kmer) - 1):
+        for x in reversed(range(1, len(kmer_bytes))):
             prefix = kmer_bytes[:x]
             old_value = db.get(prefix, EMPTY)
-            new_value = add_to_bytes_as_set(kmer_bytes[x], old_value)
-            if old_value != new_value:
+            if kmer_bytes[x] in db.get(prefix):
+                return
+            else:
+                new_value = bytes(sorted([*old_value, kmer_bytes[x]]))
                 wb.put(prefix, new_value)
-        wb.put(kmer_bytes, END)
-
-
-def add_to_bytes_as_set(byte_to_add: int, dest: bytes):
-    return dest if byte_to_add in dest else bytes(sorted([*dest, byte_to_add]))
 
 
 def _find(path, kmer, d, db, max_mismatches):

--- a/design_guides.py
+++ b/design_guides.py
@@ -72,6 +72,8 @@ def index(kmer, db=leveldb):
 
 
 def add_to_bytes_as_set(char, dest):
+    if dest == EMPTY_BYTES:
+        return bytesu(char)
     new_value_set = set(dest)
     new_value_set.add(ord(char))
     new_value = bytes(sorted(new_value_set))

--- a/design_guides.py
+++ b/design_guides.py
@@ -73,7 +73,7 @@ def index(kmer, db=leveldb):
 
 def add_to_bytes_as_set(char, dest):
     if dest == EMPTY_BYTES:
-        return bytesu(char)
+        return bytes([ord(char)])
     new_value_set = set(dest)
     new_value_set.add(ord(char))
     new_value = bytes(sorted(new_value_set))

--- a/design_guides.py
+++ b/design_guides.py
@@ -63,8 +63,7 @@ def getKmers(sequence, k, step):
 def index(kmer, db=leveldb):
     with db.write_batch() as wb:
         for x in range(1, len(kmer) - 1):
-            prefix_str = kmer[:x]
-            prefix = bytesu(prefix_str)
+            prefix = bytesu(kmer[:x])
             old_value = db.get(prefix, EMPTY_BYTES)
             new_value = add_to_bytes_as_set(kmer[x], old_value)
             if old_value != new_value:

--- a/design_guides.py
+++ b/design_guides.py
@@ -62,12 +62,12 @@ def getKmers(sequence: str, k: int, step: int):
 
 
 def index(kmer: str, db=leveldb):
-    kmer_bytes = bytesu([*kmer, '*'])
+    kmer_bytes = bytesu(kmer + '*')
     with db.write_batch() as wb:
         for x in reversed(range(1, len(kmer_bytes))):
             prefix = kmer_bytes[:x]
             old_value = db.get(prefix, EMPTY)
-            if kmer_bytes[x] in db.get(prefix):
+            if kmer_bytes[x] in old_value:
                 return
             else:
                 new_value = bytes(sorted([*old_value, kmer_bytes[x]]))

--- a/design_guides.py
+++ b/design_guides.py
@@ -16,9 +16,8 @@ HOST_FILE = "GCF_000001405.39_GRCh38.p13_rna.fna"  # all RNA in human transcript
 # HOST_FILE = "lung-tissue-gene-cds.fa" # just lungs
 HOST_PATH = os.path.join("host", HOST_FILE)
 # ending token for tries
-END = "*"
-END_BYTES = bytesu(END)
-EMPTY_BYTES = bytesu('')
+END = bytesu("*")
+EMPTY = bytesu('')
 # path to pickle / save the trie
 REBUILD_TRIE = True
 TRIE_PATH = "trie"
@@ -38,6 +37,7 @@ OUTFILE_PATH = os.path.join("guides", "trie_guides.csv")
 
 r = redis.Redis(host='localhost', port=6379)
 leveldb = plyvel.DB("db/", create_if_missing=True)
+
 
 # trie = shelve.open(TRIE_PATH)
 
@@ -64,15 +64,15 @@ def index(kmer, db=leveldb):
     with db.write_batch() as wb:
         for x in range(1, len(kmer) - 1):
             prefix = bytesu(kmer[:x])
-            old_value = db.get(prefix, EMPTY_BYTES)
+            old_value = db.get(prefix, EMPTY)
             new_value = add_to_bytes_as_set(kmer[x], old_value)
             if old_value != new_value:
                 wb.put(prefix, new_value)
-        wb.put(bytesu(kmer), END_BYTES)
+        wb.put(bytesu(kmer), END)
 
 
 def add_to_bytes_as_set(char, dest):
-    if dest == EMPTY_BYTES:
+    if dest == EMPTY:
         return bytes([ord(char)])
     new_value_set = set(dest)
     new_value_set.add(ord(char))

--- a/design_guides.py
+++ b/design_guides.py
@@ -66,12 +66,18 @@ def index(kmer, db=leveldb):
             prefix_str = kmer[:x]
             prefix = bytesu(prefix_str)
             old_value = db.get(prefix, EMPTY_BYTES)
-            new_value_set = set(old_value)
-            new_value_set.add(ord(kmer[x]))
-            new_value = bytesu(sorted(new_value_set))
+            nextchar = kmer[x]
+            new_value = add_to_bytes_as_set(nextchar, old_value)
             if old_value != new_value:
                 wb.put(prefix, new_value)
         wb.put(bytesu(kmer), END_BYTES)
+
+
+def add_to_bytes_as_set(char, dest):
+    new_value_set = set(dest)
+    new_value_set.add(ord(char))
+    new_value = bytes(sorted(new_value_set))
+    return new_value
 
 
 def _find(path, kmer, d, db, max_mismatches):

--- a/design_guides.py
+++ b/design_guides.py
@@ -63,7 +63,7 @@ def index(kmer: str, db):
     kmer_bytes = bytesu(kmer)
     if db.get(kmer_bytes, EMPTY) != EMPTY:
         return
-    with db.write_batch() as wb:
+    with db.write_batch(transaction=True) as wb:
         wb.put(kmer_bytes, END)
         for x in reversed(range(1, len(kmer_bytes))):
             prefix = kmer_bytes[:x]

--- a/design_guides.py
+++ b/design_guides.py
@@ -76,8 +76,7 @@ def add_to_bytes_as_set(char, dest):
         return bytes([ord(char)])
     new_value_set = set(dest)
     new_value_set.add(ord(char))
-    new_value = bytes(sorted(new_value_set))
-    return new_value
+    return bytes(sorted(new_value_set))
 
 
 def _find(path, kmer, d, db, max_mismatches):

--- a/design_guides.py
+++ b/design_guides.py
@@ -3,6 +3,7 @@ import os
 import plyvel
 import redis
 from Bio import AlignIO, SeqIO
+from Bio.Seq import Seq
 
 
 def bytesu(string):
@@ -46,21 +47,21 @@ def all_equal(arr):
     return arr.count(arr[0]) == len(arr)
 
 
-def read_fasta(fasta_path):
+def read_fasta(fasta_path: str) -> Seq:
     record = SeqIO.read(handle=fasta_path, format="fasta")
     return record.seq.lower()
 
 
-def write_fasta(fasta_path, sequences):
+def write_fasta(fasta_path: str, sequences):
     SeqIO.write(sequences=sequences, handle=fasta_path, format="fasta")
 
 
-def getKmers(sequence, k, step):
+def getKmers(sequence: str, k: int, step: int):
     for x in range(0, len(sequence) - k, step):
         yield sequence[x:x + k]
 
 
-def index(kmer, db=leveldb):
+def index(kmer: str, db=leveldb):
     kmer_bytes = bytesu(kmer)
     with db.write_batch() as wb:
         for x in range(1, len(kmer) - 1):
@@ -72,12 +73,8 @@ def index(kmer, db=leveldb):
         wb.put(kmer_bytes, END)
 
 
-def add_to_bytes_as_set(byte_to_add, dest):
-    if dest == EMPTY:
-        return bytes([byte_to_add])
-    new_value_set = set(dest)
-    new_value_set.add(byte_to_add)
-    return bytes(sorted(new_value_set))
+def add_to_bytes_as_set(byte_to_add: int, dest: bytes):
+    return dest if byte_to_add in dest else bytes(sorted([*dest, byte_to_add]))
 
 
 def _find(path, kmer, d, db, max_mismatches):

--- a/design_guides.py
+++ b/design_guides.py
@@ -60,8 +60,11 @@ def getKmers(sequence: str, k: int, step: int):
 
 
 def index(kmer: str, db):
-    kmer_bytes = bytesu(kmer + '*')
+    kmer_bytes = bytesu(kmer)
+    if db.get(kmer_bytes, EMPTY) != EMPTY:
+        return
     with db.write_batch() as wb:
+        wb.put(kmer_bytes, END)
         for x in reversed(range(1, len(kmer_bytes))):
             prefix = kmer_bytes[:x]
             old_value = db.get(prefix, EMPTY)

--- a/design_guides.py
+++ b/design_guides.py
@@ -12,7 +12,7 @@ def bytesu(string):
 # length of the CRISPR guide RNA
 K = 28
 # path to a fasta file with host sequences to avoid
-HOST_FILE = "GCF_000001405.39_GRCh38.p13_rna.fna" # all RNA in human transcriptome
+HOST_FILE = "GCF_000001405.39_GRCh38.p13_rna.fna"  # all RNA in human transcriptome
 # HOST_FILE = "lung-tissue-gene-cds.fa" # just lungs
 HOST_PATH = os.path.join("host", HOST_FILE)
 # ending token for tries
@@ -40,8 +40,6 @@ r = redis.Redis(host='localhost', port=6379)
 leveldb = plyvel.DB("db/", create_if_missing=True)
 
 # trie = shelve.open(TRIE_PATH)
-trie = {}
-
 
 # helpers
 def all_equal(arr):
@@ -105,7 +103,6 @@ def host_has(kmer, db=leveldb):
 def make_hosts(input_path=HOST_PATH, db=r, ldb=leveldb):
     if not REBUILD_TRIE:
         return
-    trie.clear()
     with open(input_path, "r") as host_file:
        for rcount, record in enumerate(SeqIO.parse(host_file, "fasta")):
             for kmer in getKmers(record.seq.lower(), K, 1):
@@ -163,7 +160,7 @@ def predict_side_effects(db=r, out_path=OUTFILE_PATH):
             print("good target", k, good_target_string)
             outfile.write(good_target_string + "\n")
     print(f"saved {db.zcard('good_targets')} good targets at {out_path}")
-    
+
 
 if __name__ == "__main__":
     make_hosts()

--- a/design_guides.py
+++ b/design_guides.py
@@ -74,9 +74,9 @@ def index(kmer, db=leveldb):
 
 def add_to_bytes_as_set(byte_to_add, dest):
     if dest == EMPTY:
-        return byte_to_add
+        return bytes([byte_to_add])
     new_value_set = set(dest)
-    new_value_set.add(ord(byte_to_add))
+    new_value_set.add(byte_to_add)
     return bytes(sorted(new_value_set))
 
 

--- a/design_guides.py
+++ b/design_guides.py
@@ -90,8 +90,8 @@ def find(kmer, db=leveldb, max_mismatches=CUTOFF):
     return _find("", kmer, 0, db, max_mismatches)
 
 
-def host_has(kmer, db=leveldb):
-    matches = list(find(kmer, db))
+def host_has(kmer, ldb=leveldb):
+    matches = list(find(kmer, ldb))
     should_avoid = len(matches) > 0
     notice = "avoid" if should_avoid else "allow"
     print(notice, kmer, "matches", matches)
@@ -144,11 +144,11 @@ def count_conserved(alignment, conserved, index_of_target, start):
     return kmer, n_conserved
 
 
-def predict_side_effects(db=r, out_path=OUTFILE_PATH):
+def predict_side_effects(db=r, out_path=OUTFILE_PATH, ldb=leveldb):
     targets = db.zrevrangebyscore("targets", 9001, 0)
     for target in targets:
         t = target.decode()
-        should_avoid = host_has(t)
+        should_avoid = host_has(t, ldb)
         if should_avoid:
             continue
         db.zadd("good_targets", {target: db.zscore("targets", t)})
@@ -166,7 +166,7 @@ if __name__ == "__main__":
     make_hosts(db=r, ldb=leveldb)
     # test the trie lookup works
     for i in range(5):
-        host_has(r.srandmember("hosts").decode())
+        host_has(r.srandmember("hosts").decode(), ldb=leveldb)
     make_targets(db=r)
-    predict_side_effects(db=r)
+    predict_side_effects(db=r, ldb=leveldb)
     leveldb.close()

--- a/design_guides.py
+++ b/design_guides.py
@@ -72,11 +72,11 @@ def index(kmer, db=leveldb):
         wb.put(kmer_bytes, END)
 
 
-def add_to_bytes_as_set(byte, dest):
+def add_to_bytes_as_set(byte_to_add, dest):
     if dest == EMPTY:
-        return byte
+        return byte_to_add
     new_value_set = set(dest)
-    new_value_set.add(ord(byte))
+    new_value_set.add(ord(byte_to_add))
     return bytes(sorted(new_value_set))
 
 

--- a/design_guides.py
+++ b/design_guides.py
@@ -13,8 +13,8 @@ def bytesu(string):
 # length of the CRISPR guide RNA
 K = 28
 # path to a fasta file with host sequences to avoid
-HOST_FILE = "GCF_000001405.39_GRCh38.p13_rna.fna"  # all RNA in human transcriptome
-# HOST_FILE = "lung-tissue-gene-cds.fa" # just lungs
+# HOST_FILE = "GCF_000001405.39_GRCh38.p13_rna.fna"  # all RNA in human transcriptome
+HOST_FILE = "lung-tissue-gene-cds.fa" # just lungs
 HOST_PATH = os.path.join("host", HOST_FILE)
 # ending token for tries
 END = bytesu("*")
@@ -163,10 +163,10 @@ def predict_side_effects(db=r, out_path=OUTFILE_PATH):
 if __name__ == "__main__":
     r = redis.Redis(host='localhost', port=6379)
     leveldb = plyvel.DB("db/", create_if_missing=True)
-    make_hosts()
+    make_hosts(db=r, ldb=leveldb)
     # test the trie lookup works
     for i in range(5):
         host_has(r.srandmember("hosts").decode())
-    make_targets()
-    predict_side_effects()
+    make_targets(db=r)
+    predict_side_effects(db=r)
     leveldb.close()

--- a/design_guides.py
+++ b/design_guides.py
@@ -18,6 +18,7 @@ HOST_PATH = os.path.join("host", HOST_FILE)
 # ending token for tries
 END = "*"
 END_BYTES = bytesu(END)
+EMPTY_BYTES = bytesu('')
 # path to pickle / save the trie
 REBUILD_TRIE = True
 TRIE_PATH = "trie"
@@ -66,7 +67,7 @@ def index(kmer, db=leveldb):
         for x in range(1, len(kmer) - 1):
             prefix_str = kmer[:x]
             prefix = bytesu(prefix_str)
-            old_value = db.get(prefix, '')
+            old_value = db.get(prefix, EMPTY_BYTES)
             new_value = bytesu(''.join(sorted(set(str(old_value) + kmer[x]))))
             if old_value != new_value:
                 wb.put(prefix, new_value)
@@ -104,7 +105,9 @@ def make_hosts(input_path=HOST_PATH, db=r, ldb=leveldb):
         return
     trie.clear()
     with open(input_path, "r") as host_file:
-        for rcount, record in enumerate(SeqIO.parse(host_file, "fasta")):
+        records = enumerate(SeqIO.parse(host_file, "fasta"))
+        [next(records) for x in range(116936)]
+        for rcount, record in records:
             for kmer in getKmers(record.seq.lower(), K, 1):
                 kmer_string = str(kmer)
                 db.sadd("hosts", kmer_string)

--- a/design_guides.py
+++ b/design_guides.py
@@ -39,6 +39,7 @@ OUTFILE_PATH = os.path.join("guides", "trie_guides.csv")
 r = None
 leveldb = None
 
+
 # helpers
 def all_equal(arr):
     return arr.count(arr[0]) == len(arr)
@@ -101,7 +102,7 @@ def make_hosts(input_path=HOST_PATH, db=r, ldb=leveldb):
     if not REBUILD_TRIE:
         return
     with open(input_path, "r") as host_file:
-       for rcount, record in enumerate(SeqIO.parse(host_file, "fasta")):
+        for rcount, record in enumerate(SeqIO.parse(host_file, "fasta")):
             for kmer in getKmers(record.seq.lower(), K, 1):
                 kmer_string = str(kmer)
                 db.sadd("hosts", kmer_string)

--- a/design_guides.py
+++ b/design_guides.py
@@ -102,7 +102,7 @@ def make_hosts(input_path=HOST_PATH, db=r, ldb=leveldb):
         return
     with open(input_path, "r") as host_file:
         for rcount, record in enumerate(SeqIO.parse(host_file, "fasta")):
-            with ldb.write_batch() as wb:
+            with ldb.write_batch(transaction=True) as wb:
                 for kmer in getKmers(record.seq.lower(), K, 1):
                     kmer_string = str(kmer)
                     db.sadd("hosts", kmer_string)

--- a/design_guides.py
+++ b/design_guides.py
@@ -66,7 +66,10 @@ def index(kmer, db=leveldb):
         for x in range(1, len(kmer) - 1):
             prefix_str = kmer[:x]
             prefix = bytesu(prefix_str)
-            wb.put(prefix, bytesu(''.join(set(str(db.get(prefix, '')) + kmer[x]))))
+            old_value = db.get(prefix, '')
+            new_value = bytesu(''.join(set(str(old_value) + kmer[x])))
+            if old_value != new_value:
+                wb.put(prefix, new_value)
         wb.put(bytesu(kmer), END_BYTES)
 
 

--- a/design_guides.py
+++ b/design_guides.py
@@ -66,17 +66,17 @@ def index(kmer, db=leveldb):
         for x in range(1, len(kmer) - 1):
             prefix = kmer_bytes[:x]
             old_value = db.get(prefix, EMPTY)
-            new_value = add_to_bytes_as_set(kmer[x], old_value)
+            new_value = add_to_bytes_as_set(kmer_bytes[x], old_value)
             if old_value != new_value:
                 wb.put(prefix, new_value)
         wb.put(kmer_bytes, END)
 
 
-def add_to_bytes_as_set(char, dest):
+def add_to_bytes_as_set(byte, dest):
     if dest == EMPTY:
-        return bytes([ord(char)])
+        return byte
     new_value_set = set(dest)
-    new_value_set.add(ord(char))
+    new_value_set.add(ord(byte))
     return bytes(sorted(new_value_set))
 
 

--- a/design_guides.py
+++ b/design_guides.py
@@ -67,7 +67,7 @@ def index(kmer, db=leveldb):
             prefix_str = kmer[:x]
             prefix = bytesu(prefix_str)
             old_value = db.get(prefix, '')
-            new_value = bytesu(''.join(set(str(old_value) + kmer[x])))
+            new_value = bytesu(''.join(sorted(set(str(old_value) + kmer[x]))))
             if old_value != new_value:
                 wb.put(prefix, new_value)
         wb.put(bytesu(kmer), END_BYTES)

--- a/design_guides.py
+++ b/design_guides.py
@@ -36,11 +36,8 @@ TAIL_PATH = os.path.join("parts", "tail.fa")
 # path for output
 OUTFILE_PATH = os.path.join("guides", "trie_guides.csv")
 
-r = redis.Redis(host='localhost', port=6379)
-leveldb = plyvel.DB("db/", create_if_missing=True)
-
-
-# trie = shelve.open(TRIE_PATH)
+r = None
+leveldb = None
 
 # helpers
 def all_equal(arr):
@@ -68,7 +65,7 @@ def index(kmer: str, db=leveldb):
             prefix = kmer_bytes[:x]
             old_value = db.get(prefix, EMPTY)
             if kmer_bytes[x] in old_value:
-                return
+                return  # this prefix is shared with a kmer that's already indexed
             else:
                 new_value = bytes(sorted([*old_value, kmer_bytes[x]]))
                 wb.put(prefix, new_value)
@@ -163,6 +160,8 @@ def predict_side_effects(db=r, out_path=OUTFILE_PATH):
 
 
 if __name__ == "__main__":
+    r = redis.Redis(host='localhost', port=6379)
+    leveldb = plyvel.DB("db/", create_if_missing=True)
     make_hosts()
     # test the trie lookup works
     for i in range(5):

--- a/design_guides.py
+++ b/design_guides.py
@@ -105,9 +105,7 @@ def make_hosts(input_path=HOST_PATH, db=r, ldb=leveldb):
         return
     trie.clear()
     with open(input_path, "r") as host_file:
-        records = enumerate(SeqIO.parse(host_file, "fasta"))
-        [next(records) for x in range(116936)]
-        for rcount, record in records:
+       for rcount, record in enumerate(SeqIO.parse(host_file, "fasta")):
             for kmer in getKmers(record.seq.lower(), K, 1):
                 kmer_string = str(kmer)
                 db.sadd("hosts", kmer_string)

--- a/test_design_guides.py
+++ b/test_design_guides.py
@@ -47,7 +47,7 @@ class Test(TestCase):
                          ("ggtttatcccttcccaggtagcaaacca", 9))
 
     def test_add_to_bytes_as_set(self):
-        self.assertEqual(b'ACGT', add_to_bytes_as_set('G', b'TCA'))
-        self.assertEqual(b'ACGT', add_to_bytes_as_set('G', b'ACGT'))
-        self.assertEqual(b'T', add_to_bytes_as_set('T', b''))
-        self.assertEqual(b'T', add_to_bytes_as_set('T', b'T'))
+        self.assertEqual(b'ACGT', add_to_bytes_as_set(b'G', b'TCA'))
+        self.assertEqual(b'ACGT', add_to_bytes_as_set(b'G', b'ACGT'))
+        self.assertEqual(b'T', add_to_bytes_as_set(b'T', b''))
+        self.assertEqual(b'T', add_to_bytes_as_set(b'T', b'T'))

--- a/test_design_guides.py
+++ b/test_design_guides.py
@@ -79,7 +79,8 @@ class Test(TestCase):
 
     def test_index(self):
         fake_leveldb = FakeLevelDb()
-        index('acctg', fake_leveldb)
+        with fake_leveldb.write_batch() as wb:
+            index('acctg', fake_leveldb, wb)
         self.assertDictEqual(fake_leveldb.my_dict, {
             b'a': b'c',
             b'ac': b'c',
@@ -87,7 +88,8 @@ class Test(TestCase):
             b'acct': b'g',
             b'acctg': b'*'})
         for x in range(2):  # Should be idempotent
-            index('accgc', fake_leveldb)
+            with fake_leveldb.write_batch() as wb:
+                index('accgc', fake_leveldb, wb)
             self.assertDictEqual(fake_leveldb.my_dict, {
                 b'a': b'c',
                 b'ac': b'c',

--- a/test_design_guides.py
+++ b/test_design_guides.py
@@ -1,9 +1,8 @@
 from unittest import TestCase
 
+from Bio import SeqIO
+
 from design_guides import conserved_in_alignment, count_conserved, K, add_to_bytes_as_set
-from Bio import AlignIO, SeqIO
-from datetime import datetime
-from Bio.Seq import Seq
 
 
 # noinspection SpellCheckingInspection

--- a/test_design_guides.py
+++ b/test_design_guides.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 
-from design_guides import conserved_in_alignment, count_conserved, K
+from design_guides import conserved_in_alignment, count_conserved, K, add_to_bytes_as_set
 from Bio import AlignIO, SeqIO
 from datetime import datetime
 from Bio.Seq import Seq
@@ -46,3 +46,9 @@ class Test(TestCase):
         # Has bases 15-21 conserved
         self.assertEqual(count_conserved(self.alignment, self.conserved, 0, 6),
                          ("ggtttatcccttcccaggtagcaaacca", 9))
+
+    def test_add_to_bytes_as_set(self):
+        self.assertEqual(b'ACGT', add_to_bytes_as_set(b'G', b'TCA'))
+        self.assertEqual(b'ACGT', add_to_bytes_as_set(b'G', b'ACGT'))
+        self.assertEqual(b'T', add_to_bytes_as_set(b'T', b''))
+        self.assertEqual(b'T', add_to_bytes_as_set(b'T', b'T'))

--- a/test_design_guides.py
+++ b/test_design_guides.py
@@ -47,7 +47,7 @@ class Test(TestCase):
                          ("ggtttatcccttcccaggtagcaaacca", 9))
 
     def test_add_to_bytes_as_set(self):
-        self.assertEqual(b'ACGT', add_to_bytes_as_set(b'G', b'TCA'))
-        self.assertEqual(b'ACGT', add_to_bytes_as_set(b'G', b'ACGT'))
-        self.assertEqual(b'T', add_to_bytes_as_set(b'T', b''))
-        self.assertEqual(b'T', add_to_bytes_as_set(b'T', b'T'))
+        self.assertEqual(b'ACGT', add_to_bytes_as_set(ord('G'), b'TCA'))
+        self.assertEqual(b'ACGT', add_to_bytes_as_set(ord('G'), b'ACGT'))
+        self.assertEqual(b'T', add_to_bytes_as_set(ord('T'), b''))
+        self.assertEqual(b'T', add_to_bytes_as_set(ord('T'), b'T'))

--- a/test_design_guides.py
+++ b/test_design_guides.py
@@ -47,7 +47,7 @@ class Test(TestCase):
                          ("ggtttatcccttcccaggtagcaaacca", 9))
 
     def test_add_to_bytes_as_set(self):
-        self.assertEqual(b'ACGT', add_to_bytes_as_set(b'G', b'TCA'))
-        self.assertEqual(b'ACGT', add_to_bytes_as_set(b'G', b'ACGT'))
-        self.assertEqual(b'T', add_to_bytes_as_set(b'T', b''))
-        self.assertEqual(b'T', add_to_bytes_as_set(b'T', b'T'))
+        self.assertEqual(b'ACGT', add_to_bytes_as_set('G', b'TCA'))
+        self.assertEqual(b'ACGT', add_to_bytes_as_set('G', b'ACGT'))
+        self.assertEqual(b'T', add_to_bytes_as_set('T', b''))
+        self.assertEqual(b'T', add_to_bytes_as_set('T', b'T'))

--- a/test_design_guides.py
+++ b/test_design_guides.py
@@ -10,7 +10,7 @@ class FakeWriteBatch:
         self.leveldb = leveldb
 
     def __enter__(self):
-        self.my_dict = {}
+        self.my_dict: dict[bytes, bytes] = {}
         return self
 
     def put(self, key, value):
@@ -86,12 +86,13 @@ class Test(TestCase):
             b'acc': b't',
             b'acct': b'g',
             b'acctg': b'*'})
-        index('accgc', fake_leveldb)
-        self.assertDictEqual(fake_leveldb.my_dict, {
-            b'a': b'c',
-            b'ac': b'c',
-            b'acc': b'gt',
-            b'accg': b'c',
-            b'acct': b'g',
-            b'accgc': b'*',
-            b'acctg': b'*'})
+        for x in range(2):  # Should be idempotent
+            index('accgc', fake_leveldb)
+            self.assertDictEqual(fake_leveldb.my_dict, {
+                b'a': b'c',
+                b'ac': b'c',
+                b'acc': b'gt',
+                b'accg': b'c',
+                b'acct': b'g',
+                b'accgc': b'*',
+                b'acctg': b'*'})

--- a/test_design_guides.py
+++ b/test_design_guides.py
@@ -79,8 +79,7 @@ class Test(TestCase):
 
     def test_index(self):
         fake_leveldb = FakeLevelDb()
-        with fake_leveldb.write_batch() as wb:
-            index('acctg', fake_leveldb, wb)
+        index('acctg', fake_leveldb)
         self.assertDictEqual(fake_leveldb.my_dict, {
             b'a': b'c',
             b'ac': b'c',
@@ -88,8 +87,7 @@ class Test(TestCase):
             b'acct': b'g',
             b'acctg': b'*'})
         for x in range(2):  # Should be idempotent
-            with fake_leveldb.write_batch() as wb:
-                index('accgc', fake_leveldb, wb)
+            index('accgc', fake_leveldb)
             self.assertDictEqual(fake_leveldb.my_dict, {
                 b'a': b'c',
                 b'ac': b'c',

--- a/test_design_guides.py
+++ b/test_design_guides.py
@@ -46,8 +46,3 @@ class Test(TestCase):
         self.assertEqual(count_conserved(self.alignment, self.conserved, 0, 6),
                          ("ggtttatcccttcccaggtagcaaacca", 9))
 
-    def test_add_to_bytes_as_set(self):
-        self.assertEqual(b'ACGT', add_to_bytes_as_set(ord('G'), b'TCA'))
-        self.assertEqual(b'ACGT', add_to_bytes_as_set(ord('G'), b'ACGT'))
-        self.assertEqual(b'T', add_to_bytes_as_set(ord('T'), b''))
-        self.assertEqual(b'T', add_to_bytes_as_set(ord('T'), b'T'))


### PR DESCRIPTION
* Use one write batch per record, rather than per kmer.
* Stop redundantly indexing when a common prefix with an already-indexed kmer is found. (This gives an increasing return as the trie fills up.)
* Don't add a write to the batch when the current value needs to be checked anyway and isn't changing.
* Eliminates construction of a set data structure for every prefix of every kmer.
* Adds a unit test for index() with a fake LevelDB instance.