### PR TITLE
Fix Makefile issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 SHELL=/bin/bash
 
+# Prerequisites on Ubuntu: apt install docker-compose docker.io 
+
 scylla:
 	sudo mkdir -p /var/lib/scylla/data /var/lib/scylla/commitlog
 	sudo systemctl unmask docker

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ schema: scylla
 	docker exec -it scylla cqlsh -e "create table rna.targets (target text, n bigint, start bigint, kmer text, score float, host_has boolean, side_effect boolean, overlaps boolean, primary key ((target), score, n)) with clustering order by (score desc);"
 
 transcriptome:
-	cd data/host && wget ftp://ftp.ncbi.nlm.nih.gov/genomes/all/GCF/000/001/405/GCF_000001405.39_GRCh38.p13/GCF_000001405.39_GRCh38.p13_rna.fna.gz
+	cd data/host && wget ftp://ftp.ncbi.nlm.nih.gov/genomes/all/GCF/000/001/405/GCF_000001405.39_GRCh38.p13/GCF_000001405.39_GRCh38.p13_rna.fna.gz && gunzip GCF_000001405.39_GRCh38.p13_rna.fna.gz
 
 test:  
 	pytest

--- a/Makefile
+++ b/Makefile
@@ -9,10 +9,10 @@ scylla:
 	docker-compose up -d
 	
 schema: scylla
-	until docker exec -it scylla cqlsh -e "create keyspace rna with replication = {'class':'SimpleStrategy', 'replication_factor': 1};";	do :; done # work around an issue where Scylla isn't ready yet when docker-compose exits
+	until docker exec -it scylla cqlsh -e "create keyspace rna with replication = {'class':'SimpleStrategy', 'replication_factor': 1};";	do sleep 5; done # work around an issue where Scylla isn't ready yet when docker-compose exits
 	docker exec -it scylla cqlsh -e "create table rna.trie (pre text, next set<text>, primary key (pre));"
 	docker exec -it scylla cqlsh -e "create table rna.hosts (kmer text, primary key (kmer));"
-	docker exec -it scylla cqlsh -e "create table rna.targets (target text, n bigint, start bigint, kmer text, score float, host_has boolean, side_effect boolean, primary key ((target), score, n)) with clustering order by (score desc);"
+	docker exec -it scylla cqlsh -e "create table rna.targets (target text, n bigint, start bigint, kmer text, score float, host_has boolean, side_effect boolean, overlaps boolean, primary key ((target), score, n)) with clustering order by (score desc);"
 
 transcriptome:
 	cd data/host && wget ftp://ftp.ncbi.nlm.nih.gov/genomes/all/GCF/000/001/405/GCF_000001405.39_GRCh38.p13/GCF_000001405.39_GRCh38.p13_rna.fna.gz

--- a/bio_firewall.py
+++ b/bio_firewall.py
@@ -30,7 +30,7 @@ OFFSET_1, OFFSET_2 = 14, 21
 # path for output
 OUT_PATH = os.path.join("data", "guides", f"k{K}_cutoff{CUTOFF}_guides.csv")
 # database
-cluster = Cluster(contact_points=["127.0.1.1"])
+cluster = Cluster(contact_points=["172.28.1.1"])
 global_session = cluster.connect()
 # base -> options map
 WILDCARD = {

--- a/bio_firewall.py
+++ b/bio_firewall.py
@@ -1,13 +1,13 @@
 # why?: predict side effects in biotech
 # how?: identify K-length substrings of a target not present in a host
 # what?: hamming distance cutoff
-from cassandra.cluster import Cluster
-from Bio import AlignIO, SeqIO
-from itertools import product
 import multiprocessing as mp
-from tqdm import tqdm
 import os
+from itertools import product
 
+from Bio import AlignIO, SeqIO
+from cassandra.cluster import Cluster
+from tqdm import tqdm
 
 # cpus
 CPUS = 12
@@ -166,7 +166,7 @@ def make_targets(path=TARGET_PATH, id=TARGET_ID, k=K,
         zadd(row.n, row.kmer, row.score, row.start, overlaps=False)
     [print(r.kmer, r.score, r.start) for r in no_overlaps]
     print(f"{len(no_overlaps)} non-overlapping targets")
-    no_overlaps_db = zrevrangebyscore(filter_overlaps=1)
+    no_overlaps_db = zrevrangebyscore(filter_overlaps=True)
     assert len(list(no_overlaps_db)) == len(no_overlaps)
     return no_overlaps
 
@@ -194,7 +194,7 @@ def _host_has(target, cutoff=CUTOFF, k=K):
 
 
 def predict_side_effects(k=K, cutoff=CUTOFF):
-    for t in zrevrangebyscore(filter_overlaps=1):
+    for t in zrevrangebyscore(filter_overlaps=True):
         if _host_has(t.kmer, cutoff=cutoff):
             continue
         print(

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,24 @@
 version: '3'
 
 services:
-  scylla:
+  scylla-manager:
+    image: scylladb/scylla-manager
+    container_name: scylla-manager
+    depends_on:
+      - scylla-manager-db
+
+  scylla-manager-db:
     image: scylladb/scylla
     container_name: scylla
     volumes:
       - '/var/lib/scylla:/var/lib/scylla'
+    networks:
+      coronavirus:
+        ipv4_address: 172.28.1.1
 
+networks:
+  coronavirus:
+    ipam:
+      driver: default
+      config:
+        - subnet: 172.28.0.0/16

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '3'
+
+services:
+  scylla:
+    image: scylladb/scylla
+    container_name: scylla
+    volumes:
+      - '/var/lib/scylla:/var/lib/scylla'
+


### PR DESCRIPTION
* `make scylla` now uses `docker-compose` so that it is idempotent.
* `make schema` now waits until Scylla is alive. (This implementation is clumsy, but it works.)
* `make clean` now deletes the database.
* `make transcriptome` now unzips the downloaded file.
* Add column `rna.target.overlaps`, which was previously missing from the schema and causing an error.
* Function `zrevrangebyscore` parameter `filter_overlaps` is boolean, but was called with integers.